### PR TITLE
Enhance repository key in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "numeric-keyboard",
   "version": "0.6.0",
   "description": "Numeric keyboard for mobile browsers",
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:viclm/numeric-keyboard.git"
+  "repository": "viclm/numeric-keyboard"
   },
   "main": "dist/numeric_keyboard.vanilla.js",
   "scripts": {


### PR DESCRIPTION
This way the [package info page](https://www.npmjs.com/package/numeric-keyboard) on the npm website will provide a link to repository on GitHub.

See this example:
https://github.com/micromata/cli-error-notifier/blob/master/package.json#L6
⬇️ 
https://www.npmjs.com/package/cli-error-notifier